### PR TITLE
fix bell limit type filter

### DIFF
--- a/Garland.Web/bell/gt.bell.js
+++ b/Garland.Web/bell/gt.bell.js
@@ -367,11 +367,11 @@ gt.bell = {
                 return true;
             if (!filters.botanist && (def.type == "良材" || def.type == "草场"))
                 return true;
-            if (!filters.unspoiled && def.name == "Unspoiled")
+            if (!filters.unspoiled && def.name == "未知的")
                 return true;
-            if (!filters.ephemeral && def.name == "Ephemeral")
+            if (!filters.ephemeral && def.name == "限时的")
                 return true;
-            if (!filters.legendary && def.name == "Legendary")
+            if (!filters.legendary && def.name == "传说的")
                 return true;
             if (filters.reducibleOnly && !_.any(def.items, function(i) { return i.reduce; }))
                 return true;


### PR DESCRIPTION
修复国服站 bell 的这里：
<img width="110" height="137" alt="bell-limit-type-filter" src="https://github.com/user-attachments/assets/a01bd74e-7db9-41ca-8dc0-7e48333c0b15" />

看着应该是网页端当时保留英文来兼容数据：
<img width="978" height="314" alt="bell-blame-1" src="https://github.com/user-attachments/assets/2c5716ed-1f56-40a3-82b8-21607f21fbc9" />
但是后来数据里也改成了中文：
<img width="732" height="186" alt="bell-blame-2" src="https://github.com/user-attachments/assets/99ff2b8c-29be-4229-a98b-0f8653f9f46d" />